### PR TITLE
Fix precision in chrome tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,3 @@ tests/frames/rendered/*.png
 tests/shots/*
 cacert.pem
 tmp
-
-trace.json
-trace_nested.json

--- a/src/fidget2/measure.nim
+++ b/src/fidget2/measure.nim
@@ -155,7 +155,7 @@ when isMainModule:
     run(10)
 
   endTrace()
-  dumpMeasures(0.0, "trace.json")
+  dumpMeasures(0.0, "tmp/trace.json")
 
   # Trace test: nested functions with high precision timings.
   # best tested with -d:release
@@ -173,6 +173,6 @@ when isMainModule:
   startTrace()
   outer()
   endTrace()
-  dumpMeasures(0.0, "trace_nested.json")
+  dumpMeasures(0.0, "tmp/trace_nested.json")
 
   echo "done"


### PR DESCRIPTION
- fix precision in chrome tracing
- add a test for precision 

new:

<img width="1825" height="267" alt="Screenshot From 2025-10-22 16-32-00" src="https://github.com/user-attachments/assets/e58e2631-12d1-4a61-90ec-530bc255f83b" />

previous bad behavior:

<img width="1825" height="267" alt="Screenshot From 2025-10-22 16-29-40" src="https://github.com/user-attachments/assets/0c679306-bb88-49f0-a999-c0c5cc7d5916" />
