### PR TITLE
CI: move to setup-nim-action@v6 (Nimby 0.2.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,18 +12,30 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: treeform/setup-nim-action@v5
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
       - uses: mymindstorm/setup-emsdk@v14
 
       - name: Install system dependencies
-        if: runner.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
 
+      # Nimby installs packages as siblings of the workspace root, so the
+      # workspace has to be the parent of this checkout: fidget2 then sits
+      # inside it next to its dependencies and nim finds nim.cfg by walking up.
+      - name: Create a Nimby workspace
+        shell: bash
+        run: |
+          cd ..
+          nimby create
+
       - name: Install Nim packages
-        run: nimby install fidget2.nimble
+        shell: bash
+        run: |
+          cd ..
+          nimby install fidget2/fidget2.nimble
 
       - name: List Installed Nim packages
         run: nimby tree fidget2
@@ -35,7 +47,8 @@ jobs:
         run: nim c -r --d:cpu -d:release tests/run_frames.nim
 
       - name: Install examples dependencies
-        run: nimby install chrono
+        shell: bash
+        run: cd .. && nimby install chrono
 
       - name: Compile Examples
         run: nim c -r tests/compile_examples.nim

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,11 +11,23 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: treeform/setup-nim-action@v5
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+
+      # Nimby installs packages as siblings of the workspace root, so the
+      # workspace has to be the parent of this checkout: fidget2 then sits
+      # inside it next to its dependencies and nim finds nim.cfg by walking up.
+      - name: Create a Nimby workspace
+        shell: bash
+        run: |
+          cd ..
+          nimby create
 
       - name: Install Nim packages
-        run: nimby install fidget2.nimble
+        shell: bash
+        run: |
+          cd ..
+          nimby install fidget2/fidget2.nimble
 
       - name: Generate documentation
         run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}


### PR DESCRIPTION
Moves CI to `treeform/setup-nim-action@v6`, which ships Nim 2.2.10 with **Nimby 0.2.0** bundled.

Not just a tag bump — Nimby 0.2.0 made workspaces explicit, which breaks the old command.

### What was breaking

`nimby install fidget2.nimble` in the checkout root now fails outright under 0.2.0:

```
No Nimby workspace found.
Refusing to create one inside package or Git checkout: .../fidget2
```

The workspace is now created in the checkout's **parent**, so fidget2 sits inside it next to its dependencies and nim finds `nim.cfg` by walking up. That placement is load-bearing: a workspace under `RUNNER_TEMP` installs the packages but the build won't see them.

### Bonus fix: the system dependency step has never run

```yaml
if: runner.os == 'ubuntu-latest'   # always false
```

`runner.os` is `Linux`, never `ubuntu-latest`, so the mesa/X11 dev packages were never installed on any run. Corrected to `runner.os == 'Linux'`.

⚠️ **This means the step runs for the first time in this PR.** The build is currently green without those packages, so please check the ubuntu job — if apt-get causes trouble, the honest alternative is to delete the step rather than leave a condition that can never fire.

### Verification

Every `run:` step was parsed from these YAML files and executed against the bit-identical v6 artifact (SHA-256 matched the release asset), in a sandbox with `USERPROFILE` redirected:

- `build.yml` — workspace, install, `nimby tree`, `run_frames` tests, and the full `compile_examples` run all pass
- `docs.yml` — full run, produces the expected `.gh-pages` tree with `index.html`

Notably `run_frames` passed **without** a Figma token. The `apt-get` and `FIGMA_TOKEN` steps were the only ones not exercised locally.

Local runs were Windows-only; this PR's CI covers ubuntu/macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)